### PR TITLE
Removed unnecessary GroupBy

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -17,8 +17,9 @@ namespace NugetCacheCleaner
             {
                 foreach (var versionFolder in folder.GetDirectories())
                 {
-                    var folderInfo = versionFolder.GetFiles("*.*", SearchOption.AllDirectories).GroupBy(i => 1).Select(g => new { Size = g.Sum(f => f.Length), LastAccessTime = g.Max(f => f.LastAccessTime) }).First();
-                    var lastAccessed = DateTime.Now - folderInfo.LastAccessTime;
+                    var files = versionFolder.GetFiles("*.*", SearchOption.AllDirectories);
+                    var size = files.Sum(f => f.Length);
+                    var lastAccessed = DateTime.Now - files.Max(f => f.LastAccessTime);
                     if (lastAccessed > TimeSpan.FromDays(minDays))
                     {
                         Console.WriteLine($"{versionFolder.FullName} last accessed {Math.Floor(lastAccessed.TotalDays)} days ago");
@@ -26,7 +27,7 @@ namespace NugetCacheCleaner
                         {
                             versionFolder.MoveTo(Path.Combine(versionFolder.Parent.FullName, "_" + versionFolder.Name)); //Attempt to rename before deleting
                             versionFolder.Delete(true);
-                            totalDeleted += folderInfo.Size;
+                            totalDeleted += size;
                         }
                         catch { }
                     }
@@ -35,7 +36,7 @@ namespace NugetCacheCleaner
                     folder.Delete(true);
             }
             var mbDeleted = (totalDeleted / 1024d / 1024d).ToString("0");
-            Console.WriteLine($"Done! Deleted {mbDeleted} Mb");
+            Console.WriteLine($"Done! Deleted {mbDeleted} MB.");
         }
     }
 }


### PR DESCRIPTION
I found the `GroupBy` hard to follow and it's completely unnecessary. This code is shorter and I think also easier to understand.

Also, corrected unit (Mb is magebits, MB is megabytes).