### PR TITLE
Fix for *nix; don't assume Windows path separator

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,7 +10,7 @@ namespace NugetCacheCleaner
         {
             int minDays = 30;
             if (args.Length > 0 && int.TryParse(args[0], out minDays)) { }
-            string nugetcache = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.nuget\\packages\\";
+            string nugetcache = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
             DirectoryInfo info = new DirectoryInfo(nugetcache);
             long totalDeleted = 0;
             foreach (var folder in info.GetDirectories())


### PR DESCRIPTION
Before this PR, running on macOS or a *nix host fails due to the following error:

```
Unhandled Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/johndoe\.nuget\packages\'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerableFactory.DirectoryInfos(String directory, String expression, EnumerationOptions options)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.GetDirectories(String searchPattern, EnumerationOptions enumerationOptions)
   at System.IO.DirectoryInfo.GetDirectories()
   at NugetCacheCleaner.Program.Main(String[] args) in /Users/johndoe/projects/nuget-gc/src/Program.cs:line 16
```

After this PR, it's all rainbows. 🌈 