### PR TITLE
Do dry-run by default, requiring -f to really purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ comment][code-origin].
 
 ## Usage
 
-    $ dotnet nuget-gc [minimum-days]
+    $ dotnet nuget-gc [-f|--force] [MINIMUM-DAYS]
 
-* `minimum-days`. Number of days a package must not be used in order to be
+where:
+
+* `MINIMUM-DAYS`. Number of days a package must not be used in order to be
   purged from the cache. Defaults to `30`.
+* `-f`, `--force`. Performs the actual clean-up. Default is to do a dry-run
+  and report the clean-up that would be done.

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -8,8 +8,29 @@ namespace NugetCacheCleaner
     {
         static void Main(string[] args)
         {
-            int minDays = 30;
-            if (args.Length > 0 && int.TryParse(args[0], out minDays)) { }
+            var flags = args.Where(arg => arg.Length > 0 && arg[0] == '-').ToArray();
+            const string forceName = "--force"; const string forceShortName = "-f";
+            var force = flags.Any(arg => arg == forceShortName || arg == forceName);
+
+            void Delete(DirectoryInfo dir, bool withLockCheck)
+            {
+                if (!force)
+                    return;
+
+                if (withLockCheck) // This may only be good enough for Windows
+                {
+                    var tempPath = Path.Join(dir.Parent.FullName, "_" + dir.Name);
+                    dir.MoveTo(tempPath); // Attempt to rename before deleting
+                    Directory.Delete(tempPath, recursive: true);
+                }
+                else
+                {
+                    dir.Delete(recursive: true);
+                }
+            }
+
+            var tail = args.Except(flags);
+            var minDays = int.TryParse(tail.FirstOrDefault(), out var n) ? n : 30;
             string nugetcache = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.nuget\\packages\\";
             DirectoryInfo info = new DirectoryInfo(nugetcache);
             long totalDeleted = 0;
@@ -25,18 +46,19 @@ namespace NugetCacheCleaner
                         Console.WriteLine($"{versionFolder.FullName} last accessed {Math.Floor(lastAccessed.TotalDays)} days ago");
                         try
                         {
-                            versionFolder.MoveTo(Path.Combine(versionFolder.Parent.FullName, "_" + versionFolder.Name)); //Attempt to rename before deleting
-                            versionFolder.Delete(true);
+                            Delete(versionFolder, withLockCheck: true);
                             totalDeleted += size;
                         }
                         catch { }
                     }
                 }
                 if (folder.GetDirectories().Length == 0)
-                    folder.Delete(true);
+                    Delete(folder, withLockCheck: false);
             }
             var mbDeleted = (totalDeleted / 1024d / 1024d).ToString("0");
-            Console.WriteLine($"Done! Deleted {mbDeleted} MB.");
+            Console.WriteLine(
+                force ? $"Done! Deleted {mbDeleted} MB."
+                      : $"Will delete {mbDeleted} MB. Re-run with {forceShortName} or {forceName} flag to really delete.");
         }
     }
 }


### PR DESCRIPTION
This PR changes the behaviour to do a dry-run (no destructive operation or changes to system) by default and report what would be purged and only does a real purge if the user specified the `-f` or `--force` flag.
