### PR TITLE
Check for empty version folder

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -78,6 +78,11 @@ namespace NugetCacheCleaner
                 foreach (var versionFolder in folder.GetDirectories())
                 {
                     var files = versionFolder.GetFiles("*.*", SearchOption.AllDirectories);
+                    if (files.Length == 0)
+                    {
+                        Delete(versionFolder, force, withLockCheck: false);
+                        continue;
+                    }
                     var size = files.Sum(f => f.Length);
                     var lastAccessed = DateTime.Now - files.Max(f => f.LastAccessTime);
                     if (lastAccessed > minDays)


### PR DESCRIPTION
Love this tool!

When running this today I ran into an exception where one of my package folders had a version folder with no contents. It may be unusual to get into this state (maybe an aborted restore?), but I thought it would be good to handle it regardless.