### PR TITLE
Fix for issue #12 - Handling missing ~/.nuget/packages directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get the directory path of this script.
+# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+CMD_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "${CMD_HOME}" || exit 1
+
+SLN=${CMD_HOME}/src/dotnet-nuget-gc.csproj
+BIN=${CMD_HOME}/bin/
+CONFIG=release
+
+dotnet build "${SLN}" -c ${CONFIG} -o="${BIN}" -nologo


### PR DESCRIPTION
https://github.com/terrajobst/dotnet-nuget-gc/issues/12

An ugly exception (see below) is thrown if the `~/.nuget/packages` directory is missing when running nuget-gc.

# Failure mode:

```
$ dotnet nuget-gc

Unhandled Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path '/home/MYUSER/.nuget/packages'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerableFactory.DirectoryInfos(String directory, String expression, EnumerationOptions options)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.GetDirectories(String searchPattern, EnumerationOptions enumerationOptions)
   at System.IO.DirectoryInfo.GetDirectories()
   at NugetCacheCleaner.Program.CleanCache(Boolean force, TimeSpan minDays) in /home/vsts/work/1/s/src/Program.cs:line 75
   at NugetCacheCleaner.Program.Main(String[] args) in /home/vsts/work/1/s/src/Program.cs:line 40
```

Fixes issue #12