### PR TITLE
Update to .NET 5.0, add option for pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,6 @@ comment][code-origin].
                                  done.
       -m, --min-days=VALUE       Number of days a package must not be used in order
                                  to be purged from the cache. Defaults to 90.
+      -p, --prune                prune older versions of packages regardless of age
       -?, -h, --help             show this message and exit
+

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ comment][code-origin].
                                  dry-run and report the clean-up that would be
                                  done.
       -m, --min-days=VALUE       Number of days a package must not be used in order
-                                 to be purged from the cache. Defaults to 30.
+                                 to be purged from the cache. Defaults to 90.
       -?, -h, --help             show this message and exit

--- a/dotnet-nuget-gc.sln
+++ b/dotnet-nuget-gc.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-nuget-gc", "src\dotnet-nuget-gc.csproj", "{A9AB4F95-C775-462A-8A49-62E3E701A119}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{D4DADB7C-5D3B-4C0A-8874-B6FE59008936}"
+ProjectSection(SolutionItems) = preProject
+	LICENSE = LICENSE
+	README.md = README.md
+EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A9AB4F95-C775-462A-8A49-62E3E701A119}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9AB4F95-C775-462A-8A49-62E3E701A119}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9AB4F95-C775-462A-8A49-62E3E701A119}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9AB4F95-C775-462A-8A49-62E3E701A119}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/dotnet-nuget-gc.sln.DotSettings
+++ b/dotnet-nuget-gc.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=prereleases/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Mono.Options;
+using NuGet.Versioning;
 
 namespace NugetCacheCleaner
 {
@@ -13,10 +14,19 @@ namespace NugetCacheCleaner
             var force = false;
             var showHelp = false;
             var minDays = TimeSpan.FromDays(90);
+            var prune = false;
 
-            var options = new OptionSet {
-                {"f|force", "Performs the actual clean-up. Default is to do a dry-run and report the clean-up that would be done.", v => force = v != null},
-                {"m|min-days=", "Number of days a package must not be used in order to be purged from the cache. Defaults to 90.", v => minDays = ParseDays(v)},
+            var options = new OptionSet
+            {
+                {
+                    "f|force", "Performs the actual clean-up. Default is to do a dry-run and report the clean-up that would be done.",
+                    v => force = v is not null
+                },
+                {
+                    "m|min-days=", "Number of days a package must not be used in order to be purged from the cache. Defaults to 90.",
+                    v => minDays = ParseDays(v)
+                },
+                { "p|prune", "Prune older versions of packages regardless of age.", v => prune = v is not null },
                 { "?|h|help", "Show this message.", v => showHelp = v != null },
             };
 
@@ -37,7 +47,7 @@ namespace NugetCacheCleaner
                 return;
             }
 
-            var totalDeleted = CleanCache(force, minDays);
+            var totalDeleted = CleanCache(force, minDays, prune);
             var mbDeleted = (totalDeleted / 1024d / 1024d).ToString("N0");
 
             if (force)
@@ -56,7 +66,7 @@ namespace NugetCacheCleaner
             Console.WriteLine("usage: dotnet nuget-gc [options]");
             Console.WriteLine();
             Console.WriteLine("Options:");
-            optionSet.WriteOptionDescriptions (Console.Out);
+            optionSet.WriteOptionDescriptions(Console.Out);
         }
 
         private static TimeSpan ParseDays(string text)
@@ -67,54 +77,89 @@ namespace NugetCacheCleaner
             return TimeSpan.FromDays(days);
         }
 
-        private static long CleanCache(bool force, TimeSpan minDays)
+        private static long CleanCache(bool force, TimeSpan minDays, bool prune)
         {
             var userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var nugetCachePath = Path.Join(userProfilePath, ".nuget", "packages");
             var nugetCache = new DirectoryInfo(nugetCachePath);
             var totalDeleted = 0L;
+
+            void CleanPackageDirectory(DirectoryInfo dir)
+            {
+                var versions = new Dictionary<NuGetVersion, DirectoryInfo>();
+                foreach (var versionDir in dir.GetDirectories())
+                {
+                    var files = versionDir.GetFiles("*.*", SearchOption.AllDirectories);
+                    if (files.Length == 0)
+                    {
+                        Delete(versionDir, force, withLockCheck: false);
+                        continue;
+                    }
+                    if (!NuGetVersion.TryParse(versionDir.Name, out var version))
+                    {
+                        //Delete(versionFolder, force, withLockCheck: false);
+                        Console.WriteLine($"Warning: Skipping non-version format directory {versionDir.FullName}.");
+                        continue;
+                    }
+                    versions.Add(version, versionDir);
+                    var size = files.Sum(f => f.Length);
+                    var lastAccessed = DateTime.UtcNow - files.Max(GetLastAccessed);
+                    if (lastAccessed > minDays)
+                    {
+                        Console.WriteLine($"{versionDir.FullName} last accessed {Math.Floor(lastAccessed.TotalDays)} days ago");
+                        try
+                        {
+                            Delete(versionDir, force, withLockCheck: true);
+                            totalDeleted += size;
+                        }
+                        catch (FileNotFoundException)
+                        {
+                            // ok
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            Console.WriteLine($"Warning: Not authorized to delete {versionDir.FullName}.");
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine($"Warning: Deleting {versionDir.FullName} encountered {ex.GetType().Name}: {ex.Message}");
+                        }
+                    }
+                }
+                if (prune)
+                {
+                    var releases = versions.Keys.Where(v => !v.IsPrerelease).ToArray();
+                    var newestRelease = releases.Any() ? releases.Max() : null;
+                    var prereleases = versions.Keys.Where(v => v > newestRelease && v.IsPrerelease).ToArray();
+                    var newestPrerelease = prereleases.Any() ? prereleases.Max() : null;
+                    foreach (var versionedDir in versions)
+                    {
+                        if (versionedDir.Key == newestRelease) continue;
+                        if (versionedDir.Key == newestPrerelease) continue;
+                        var versionDir = versionedDir.Value;
+                        var files = versionDir.GetFiles("*.*", SearchOption.AllDirectories);
+                        var size = files.Sum(f => f.Length);
+                        Delete(versionDir, force, withLockCheck: false);
+                        totalDeleted += size;
+                    }
+                }
+                if (dir.GetDirectories().Length == 0)
+                    Delete(dir, force, withLockCheck: false);
+            }
+
             if (!nugetCache.Exists)
             {
                 Console.WriteLine($"Warning: Missing nuget package folder: {nugetCache.FullName}");
             }
             else
             {
-                foreach (var folder in nugetCache.GetDirectories())
+                foreach (var dir in nugetCache.GetDirectories())
                 {
-                    foreach (var versionFolder in folder.GetDirectories())
-                    {
-                        var files = versionFolder.GetFiles("*.*", SearchOption.AllDirectories);
-                        if (files.Length == 0)
-                        {
-                            Delete(versionFolder, force, withLockCheck: false);
-                            continue;
-                        }
-                        var size = files.Sum(f => f.Length);
-                        var lastAccessed = DateTime.UtcNow - files.Max(GetLastAccessed);
-                        if (lastAccessed > minDays)
-                        {
-                            Console.WriteLine($"{versionFolder.FullName} last accessed {Math.Floor(lastAccessed.TotalDays)} days ago");
-                            try
-                            {
-                                Delete(versionFolder, force, withLockCheck: true);
-                                totalDeleted += size;
-                            }
-                            catch (FileNotFoundException)
-                            {
-                                // ok
-                            }
-                            catch (UnauthorizedAccessException)
-                            {
-                                Console.WriteLine($"Warning: Not authorized to delete {versionFolder.FullName}.");
-                            }
-                            catch (Exception ex)
-                            {
-                                Console.WriteLine($"Warning: Deleting {versionFolder.FullName} encountered {ex.GetType().Name}: {ex.Message}");
-                            }
-                        }
-                    }
-                    if (folder.GetDirectories().Length == 0)
-                        Delete(folder, force, withLockCheck: false);
+                    if (dir.Name != ".tools")
+                        CleanPackageDirectory(dir);
+                    else
+                        foreach (var toolDir in dir.GetDirectories())
+                            CleanPackageDirectory(toolDir);
                 }
             }
 
@@ -136,11 +181,21 @@ namespace NugetCacheCleaner
         private static void Delete(DirectoryInfo dir, bool force, bool withLockCheck)
         {
             if (!force)
+            {
+#if DEBUG
+                Console.WriteLine($"Would remove {dir.FullName}.");
+#endif
                 return;
+            }
+#if DEBUG
+            Console.WriteLine($"Removing {dir.FullName}.");
+#endif
 
             if (withLockCheck) // This may only be good enough for Windows
             {
-                var tempPath = Path.Join(dir.Parent.FullName, "_" + dir.Name);
+                var parentDir = dir.Parent;
+                if (parentDir == null) throw new NotImplementedException("Missing parent directory.");
+                var tempPath = Path.Join(parentDir.FullName, "_" + dir.Name);
                 dir.MoveTo(tempPath); // Attempt to rename before deleting
                 Directory.Delete(tempPath, recursive: true);
             }

--- a/src/dotnet-nuget-gc.csproj
+++ b/src/dotnet-nuget-gc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>$(OutDir)</PackageOutputPath>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>2.2.13</Version>
+      <Version>3.4.216</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/dotnet-nuget-gc.csproj
+++ b/src/dotnet-nuget-gc.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Versioning" Version="5.10.0" />
   </ItemGroup>
 
 </Project>

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "publicReleaseRefSpec": [
         "^refs/heads/master$" // we release out of master
     ]


### PR DESCRIPTION
Updates the project to .NET 5.0. Updates package dependencies.

Adds an option (`-p`, `--prune`) for pruning of versions other than latest release and prerelease.

Changes default for last accessed minimum days to 90.

Compares time in UTC.

Adds redundant fallback for LastAccessTimeUtc to LastWriteTimeUtc.

Properly collects old versions of tools (`.tools` subdirectory) instead of wiping the entire toolset.

Reports some non-trivial directory deletion failure conditions.

Note: Fallback to using LastWriteTimeUtc is probably over-redundant paranoia.

The dependency on NuGet.Versioning means it would not be hard to add functionality to keep N previous releases, keep N prereleases, keep latest of major versions, etc.